### PR TITLE
add in some optional generic queries

### DIFF
--- a/src/PPSAssociations/PPSAssociationRequest.cs
+++ b/src/PPSAssociations/PPSAssociationRequest.cs
@@ -11,15 +11,24 @@ namespace Ietws
         // retType can be 'people' or 'default'
         public async Task<PPSAssociationResults> Search(PPSAssociationsSearchField field, string value, string retType = "default")
         {
+            return await Search<PPSAssociationResults>(field, value, retType);
+        }
 
+        public async Task<T> Search<T>(PPSAssociationsSearchField field, string value, string retType = "default") where T : class
+        {
             this.Url = "iam/associations/pps/search";
 
             this.QueryItems.Add(field.ToString(), value);
 
-            return await this.GetAsync<PPSAssociationResults>();
+            return await this.GetAsync<T>();
         }
 
         public async Task<PPSAssociationIamIdResults> GetIamIds(PPSAssociationsSearchField field, string value, string retType = "default")
+        {
+            return await GetIamIds<PPSAssociationIamIdResults>(field, value, retType);
+        }
+
+        public async Task<T> GetIamIds<T>(PPSAssociationsSearchField field, string value, string retType = "default") where T : class
         {
             this.Url = "iam/associations/pps/search";
 
@@ -27,11 +36,8 @@ namespace Ietws
 
             this.QueryItems.Add("retType", "iamids");
 
-            return await this.GetAsync<PPSAssociationIamIdResults>();
-
+            return await this.GetAsync<T>();
         }
-
-
 
         public async Task<PPSAssociationResults> Get(string iamId)
         {

--- a/tests/ApiTests.cs
+++ b/tests/ApiTests.cs
@@ -112,7 +112,7 @@ namespace tests
         public async Task CanGetPPSAssociationsWithPeopleReturnType()
         {
             var client = new Ietws.IetClient(key);
-            var result = await client.PPSAssociations.Search(PPSAssociationsSearchField.iamId, "1000029584", "people");
+            var result = await client.PPSAssociations.Search<PeopleResults>(PPSAssociationsSearchField.iamId, "1000029584", "people");
 
             // 0 is success
             Assert.AreEqual(result.ResponseStatus, 0);


### PR DESCRIPTION
required because we can change up the return type